### PR TITLE
PSECBUGS-47661

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven {
-            url 'https://raw.github.com/OathAdPlatforms/OneMobileSDK-releases-android/maven/'
-        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:$gradle_android_version"
@@ -28,9 +25,6 @@ buildscript {
 
 allprojects {
     repositories {
-        maven {
-            url 'https://raw.githubusercontent.com/OathAdPlatforms/OneMobileSDK-releases-android/maven/'
-        }
         google()
         jcenter()
     }


### PR DESCRIPTION
removing the open url maven repo to address the security bug PSECBUGS-47661: Github Account Takeover which is getting as maven dependency in build.gradle of "github.com/yahoo/OneMobileSDK-videorenderer-android"

@VerizonAdPlatforms/mobile-sdk-developers: Ready for review.

[JIRA](https://jira.ouroath.com/browse/VSDK-XXXX)
